### PR TITLE
Fix security issue with marshmallow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 SQLAlchemy>=1.2.1,<1.3.0
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
 alembic==0.9.7
-marshmallow==2.15.0
+marshmallow==2.15.1
 marshmallow-enum==1.4.1


### PR DESCRIPTION
[CVE-2018-17175](https://nvd.nist.gov/vuln/detail/CVE-2018-17175)

high severity

Vulnerable versions: < 2.15.1

Patched version: 2.15.1

In the marshmallow library before 2.15.1 and 3.x before 3.0.0b9 for Python, the schema "only" option treats an empty list as implying no "only" option, which allows a request that was intended to expose no fields to instead expose all fields (if the schema is being filtered dynamically using the "only" option, and there is a user role