### PR TITLE
Add new Strava 2018 Auth fields to Athlete, fix Alembic cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # freezing-model
-SQLAlchemy model for freezing saddles database
+SQLAlchemy model for Freezing Saddles database
+==============================================
+
+This package uses [SQLAlchemy](https://www.sqlalchemy.org/) to model the
+database tables for the Freezing Saddles database. It uses
+[alembic](ihttps://pypi.org/project/alembic/) to perform database migrations. 
+
+Usage
+-----
+This is intended for use with the other
+[Freezing Saddles projects](https://github.org/freezingsaddles/) projects
+including [freezing-web](https://github.org/freezingsaddles/freezing-web).
+When used from `freezing-web` it will retrieve its database configuration
+from the [Flask](http://flask.pocoo.org/) application configuration. When
+used from the command line, it will take its configuration from the
+[alembic.ini](alembic.ini) file and optionally from the environment.
+
+You can override the database URL by specifying a `SQLALCHEMY_URL` environment
+variable, for example:
+
+    export SQLALCHEMY_URL='mysql+pymysql://user:password@127.0.0.1/freezing?charset=utf8mb4&binary_prefix=true'
+    PYTHONPATH=$(pwd) alembic current
+    PYTHONPATH=$(pwd) alembic upgrade head
+
+
+

--- a/alembic.ini
+++ b/alembic.ini
@@ -15,7 +15,8 @@ script_location = freezing.model:migrations
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-# This is read from Flask config instead
+# This is read from Flask config instead,
+# or set the SQLALCHEMY_URL environment variable
 # sqlalchemy.url = driver://user:pass@localhost/dbname
 
 

--- a/freezing/model/migrations/script.py.mako
+++ b/freezing/model/migrations/script.py.mako
@@ -1,3 +1,6 @@
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 """${message}
 
 Revision ID: ${up_revision}
@@ -10,9 +13,6 @@ Create Date: ${create_date}
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
     ${upgrades if upgrades else "pass"}

--- a/freezing/model/migrations/versions/18a82f58b63c_add_strava_2018_new_tokens.py
+++ b/freezing/model/migrations/versions/18a82f58b63c_add_strava_2018_new_tokens.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+
+"""Add Strava 2018 new tokens
+
+Revision ID: 18a82f58b63c
+Revises: c5bfe51cfec3
+Create Date: 2018-12-24 14:54:59.725988
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '18a82f58b63c'
+down_revision = 'c5bfe51cfec3'
+
+
+def upgrade():
+    op.add_column('athletes', sa.Column(
+        'refresh_token', sa.Integer, nullable=True))
+    op.add_column('athletes', sa.Column(
+        'expires_at', sa.Integer, nullable=False, default=0))
+
+
+def downgrade():
+    op.drop_column('athletes', sa.Column('refresh_token'))
+    op.drop_column('athletes', sa.Column('expires_at'))

--- a/freezing/model/orm.py
+++ b/freezing/model/orm.py
@@ -51,6 +51,8 @@ class Athlete(StravaEntity):
     team_id = Column(BigInteger, ForeignKey('teams.id', ondelete='set null'))
     access_token = Column(String(255), nullable=True)
     profile_photo = Column(String(255), nullable=True)
+    refresh_token = Column(String(255), nullable=True)
+    expires_at = Column(BigInteger, default=0)
 
     rides = orm.relationship("Ride", backref="athlete", lazy="dynamic", cascade="all, delete, delete-orphan")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ SQLAlchemy>=1.2.1,<1.3.0
 alembic==0.9.7
 marshmallow==2.15.0
 marshmallow-enum==1.4.1
+PyMySQL==0.8.0


### PR DESCRIPTION
Added support for configuring alembic through using a
`SQLALCHEMY_URL` environment variable, and tested that this works with
MySQL from the command line.

The `freezing/model/migrations/env.py` had been changed so much from the
Alembic defaults that it was no longer working to use Alembic from the
command line. This remedies that.

Also added enough documentation to give people a clue about maybe having to
set the `PYTHONPATH` environment variable when using alembic from the
command line.

Also fix up script.py.mako to generate migrations that are PEP-8 clean