### PR TITLE
Bypass logging if config_file_name is None

### DIFF
--- a/freezing/model/migrations/env.py
+++ b/freezing/model/migrations/env.py
@@ -11,7 +11,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+if (config.config_file_name):
+    fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError: # for pip <= 9.0.3
 
 from setuptools import setup, find_packages
 
-version = '0.3.1'
+version = '0.3.2'
 
 long_description = """
 freezing-model is the database model and message definitions shared by freezing saddles components.


### PR DESCRIPTION
This is an attempt to get past this error:

```
core@freezingsaddles /opt/compose $ docker-compose up -d
nginx-docker-gen is up-to-date
nginx-letsencrypt is up-to-date
beanstalkd is up-to-date
logspout is up-to-date
dd-agent is up-to-date
nginx is up-to-date
Recreating freezing-web ...
freezing-nq is up-to-date
Recreating freezing-web ... done
core@freezingsaddles /opt/compose $ docker logs freezing-web
[2018-12-29 17:24:13 +0000] [6] [INFO] Starting gunicorn 19.7.1
[2018-12-29 17:24:13 +0000] [6] [INFO] Listening at: http://0.0.0.0:8000 (6)
[2018-12-29 17:24:13 +0000] [6] [INFO] Using worker: sync
[2018-12-29 17:24:13 +0000] [9] [INFO] Booting worker with pid: 9
[2018-12-29 17:24:14 +0000] [9] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/arbiter.py", line 578, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 126, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 135, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/util.py", line 352, in import_app
    __import__(module)
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/__init__.py", line 12, in <module>
    init_model(config.SQLALCHEMY_URL)
  File "/usr/local/lib/python3.6/dist-packages/freezing/model/__init__.py", line 96, in init_model
    command.upgrade(alembic_cfg, "head")
  File "/usr/local/lib/python3.6/dist-packages/alembic/command.py", line 254, in upgrade
    script.run_env()
  File "/usr/local/lib/python3.6/dist-packages/alembic/script/base.py", line 425, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/usr/local/lib/python3.6/dist-packages/alembic/util/pyfiles.py", line 81, in load_python_file
    module = load_module_py(module_id, path)
  File "/usr/local/lib/python3.6/dist-packages/alembic/util/compat.py", line 83, in load_module_py
    spec.loader.exec_module(module)
  File "/usr/local/lib/python3.6/dist-packages/freezing/model/migrations/env.py", line 14, in <module>
    fileConfig(config.config_file_name)
  File "/usr/lib/python3.6/logging/config.py", line 74, in fileConfig
    cp.read(fname)
  File "/usr/lib/python3.6/configparser.py", line 694, in read
    for filename in filenames:
TypeError: 'NoneType' object is not iterable
[2018-12-29 17:24:14 +0000] [9] [INFO] Worker exiting (pid: 9)
[2018-12-29 17:24:15 +0000] [6] [INFO] Shutting down: Master
[2018-12-29 17:24:15 +0000] [6] [INFO] Reason: Worker failed to boot.
[2018-12-29 17:24:15 +0000] [6] [INFO] Starting gunicorn 19.7.1
```