### PR TITLE
Declining points

### DIFF
--- a/freezing/model/__init__.py
+++ b/freezing/model/__init__.py
@@ -123,11 +123,11 @@ def create_supplemental_db_objects(engine: Engine):
         where(
             case(
                 [
-                    (sum(R.distance) >= 1 & sum(R.distance <= 10), 10 + 0.5 * (21 * sum(R.distance) - sum(R.distance) * sum(R.distance))),
+                    (and_(sum(R.distance) >= 1, sum(R.distance) <= 10),
+                    10 + 0.5 * (21 * sum(R.distance) - (sum(R.distance) * sum(R.distance)))),
                     (sum(R.distance) > 10, 65 + sum(R.distance))
                 ]
             )
-            else_=0
         ) as points,
         date(CONVERT_TZ(R.start_date, R.timezone,'{0}')) as ride_date
         from rides R

--- a/freezing/model/migrations/versions/9b7cf7603b70_declining_points_system.py
+++ b/freezing/model/migrations/versions/9b7cf7603b70_declining_points_system.py
@@ -1,0 +1,50 @@
+from alembic import op
+import sqlalchemy as sa
+from freezing.model.config import config as model_config
+
+"""Update daily_scores view to refelect declining points for first 10 miles
+
+Revision ID: 9b7cf7603b70
+Revises: c8add074d30f
+Create Date: 2019-12-14 11:38:19.648650
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9b7cf7603b70'
+down_revision = 'c8add074d30f'
+
+def upgrade():
+    op.execute("""
+        create or replace VIEW `daily_scores` as
+        select A.team_id, R.athlete_id, sum(R.distance) as distance,
+        case
+            when distance < 0 then 0
+            when distance < 10 then 10 + 0.5 * (21 * distance - (distance * distance))
+            else 65 + distance
+        end as points,
+        date(CONVERT_TZ(R.start_date, R.timezone,'{0}')) as ride_date
+        from rides R
+        join athletes A on A.id = R.athlete_id
+        group by
+          R.athlete_id,
+          A.team_id,
+          date(CONVERT_TZ(R.start_date, R.timezone,'{0}'))
+        ;
+        """).format(model_config.TIMEZONE))
+
+
+def downgrade():
+    op.execute("""
+        create or replace view daily_scores as
+        select A.team_id, R.athlete_id, sum(R.distance) as distance,
+        (sum(R.distance) + IF(sum(R.distance) >= 1.0, 10,0)) as points,
+        date(CONVERT_TZ(R.start_date, R.timezone,'{0}')) as ride_date
+        from rides R
+        join athletes A on A.id = R.athlete_id
+        group by
+          R.athlete_id,
+          A.team_id,
+          date(CONVERT_TZ(R.start_date, R.timezone,'{0}'))
+        ;
+    """.format(model_config.TIMEZONE))

--- a/freezing/model/migrations/versions/9b7cf7603b70_declining_points_system.py
+++ b/freezing/model/migrations/versions/9b7cf7603b70_declining_points_system.py
@@ -5,14 +5,15 @@ from freezing.model.config import config as model_config
 """Update daily_scores view to refelect declining points for first 10 miles
 
 Revision ID: 9b7cf7603b70
-Revises: c8add074d30f
+Revises: 12a5e1aff276
 Create Date: 2019-12-14 11:38:19.648650
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '9b7cf7603b70'
-down_revision = 'c8add074d30f'
+down_revision = '12a5e1aff276'
+
 
 def upgrade():
     op.execute("""
@@ -20,7 +21,8 @@ def upgrade():
         select A.team_id, R.athlete_id, sum(R.distance) as distance,
         case
             when distance < 0 then 0
-            when distance < 10 then 10 + 0.5 * (21 * distance - (distance * distance))
+            when distance < 10
+                then 10 + 0.5 * (21 * distance - (distance * distance))
             else 65 + distance
         end as points,
         date(CONVERT_TZ(R.start_date, R.timezone,'{0}')) as ride_date
@@ -31,7 +33,7 @@ def upgrade():
           A.team_id,
           date(CONVERT_TZ(R.start_date, R.timezone,'{0}'))
         ;
-        """).format(model_config.TIMEZONE))
+        """.format(model_config.TIMEZONE))
 
 
 def downgrade():


### PR DESCRIPTION
Revises the `daily_scores` view to implement a [declining points system](http://bikearlingtonforum.com/showthread.php?15056-BAFS-2020-teams-and-rules-discussion&p=193817#post193817). A rider's first ten miles each day are weighted more heavily (on a declining basis) and miles above ten earn one point per mile. The ten point bonus for the first mile is still in effect.