### PR TITLE
pointless-poggio fixes: marshmallow is always strict now

### DIFF
--- a/freezing/model/msg/__init__.py
+++ b/freezing/model/msg/__init__.py
@@ -19,8 +19,6 @@ class BaseMessage:
 class BaseSchema(Schema):
 
     def __init__(self, *args, **kwargs):
-        if 'strict' not in kwargs:
-            kwargs['strict'] = True
         super().__init__(*args, **kwargs)
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 PyMySQL==0.9.3
 SQLAlchemy==1.3.12
 alembic==1.3.2
-arrow==0.15.4
-colorlog==4.0.2
+arrow==0.15.5
+colorlog==4.1.0
 envparse==0.2.0
 marshmallow==3.3.0
 marshmallow-enum==1.5.1


### PR DESCRIPTION
See https://github.com/marshmallow-code/marshmallow/pull/711

Our attempt to make it strict is obsolete, and was raising this error on all the generic leaderboards pages:

```

TypeError

TypeError: __init__() got an unexpected keyword argument 'strict'
Traceback (most recent call last)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__

    return self.wsgi_app(environ, start_response)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app

    response = self.handle_exception(e)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception

    reraise(exc_type, exc_value, tb)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise

    raise value

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app

    response = self.full_dispatch_request()

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request

    rv = self.handle_user_exception(e)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception

    reraise(exc_type, exc_value, tb)

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise

    raise value

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request

    rv = self.dispatch_request()

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request

    return self.view_functions[rule.endpoint](**req.view_args)

    File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/freezing/web/views/pointless.py", line 22, in generic

    board, data = load_board_and_data(leaderboard)

    File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/freezing/web/utils/genericboard.py", line 93, in load_board_and_data

    board = load_board(leaderboard)

    File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/freezing/web/utils/genericboard.py", line 116, in load_board

    schema = GenericBoardSchema()

    File "/Users/rbulling/Documents/src/freezingsaddles/.venv/src/freezing-model/freezing/model/msg/__init__.py", line 24, in __init__

    super().__init__(*args, **kwargs)

    TypeError: __init__() got an unexpected keyword argument 'strict'

```