### PR TITLE
Delayed refetch of effortless rides

### DIFF
--- a/freezing/model/__init__.py
+++ b/freezing/model/__init__.py
@@ -63,7 +63,7 @@ def init_model(sqlalchemy_url: str, drop: bool = False, check_version: bool = Tr
     fresh_db = False
 
     if not db_objects_created:
-        log.info("Database apears uninitialized, creating database tables")
+        log.info("Database appears uninitialized, creating database tables")
         meta.metadata.create_all(engine, tables=MANAGED_TABLES, checkfirst=True)
         create_supplemental_db_objects(engine)
         fresh_db = True

--- a/freezing/model/migrations/versions/d4be89cbab08_add_ride_resync_count.py
+++ b/freezing/model/migrations/versions/d4be89cbab08_add_ride_resync_count.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+"""add ride resync count
+
+Revision ID: d4be89cbab08
+Revises: 9a3b4a159362
+Create Date: 2020-01-16 23:03:57.392052
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd4be89cbab08'
+down_revision = '9a3b4a159362'
+
+
+def upgrade():
+    op.add_column('rides', sa.Column('resync_count', sa.Integer, nullable=False, default=0))
+    op.execute('update rides set efforts_fetched = false where id not in (select ride_id from ride_efforts)')
+    pass
+
+
+def downgrade():
+    op.drop_column('rides', 'resync_count')
+    pass

--- a/freezing/model/orm.py
+++ b/freezing/model/orm.py
@@ -98,6 +98,7 @@ class Ride(StravaEntity):
     photos_fetched = Column(Boolean, default=None, nullable=True)
     track_fetched = Column(Boolean, default=None, nullable=True)
     detail_fetched = Column(Boolean, default=False, nullable=False)
+    resync_count = Column(Integer, default=0, nullable=False)
 
     private = Column(Boolean, default=False, nullable=False)
     manual = Column(Boolean, default=None, nullable=True)


### PR DESCRIPTION
Under a presumption that strava has some delayed consistency, add model support for resyncing effortless rides.