### PR TITLE
add ride resync date column

### DIFF
--- a/freezing/model/migrations/versions/21518d40552c_add_ride_resync_date.py
+++ b/freezing/model/migrations/versions/21518d40552c_add_ride_resync_date.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+
+"""add ride resync date
+
+Revision ID: 21518d40552c
+Revises: d4be89cbab08
+Create Date: 2020-02-01 08:53:33.632416
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '21518d40552c'
+down_revision = 'd4be89cbab08'
+
+
+def upgrade():
+    op.add_column('rides', sa.Column('resync_date', sa.DateTime, nullable=True))
+    # we do not know which rides have partial efforts fetched so schedule them all for resync over the next few days
+    op.execute('update rides set efforts_fetched = false, resync_count = 1, resync_date = now() + interval floor(rand() * 72) hour')
+    pass
+
+
+def downgrade():
+    op.drop_column('rides', 'resync_date')
+    pass

--- a/freezing/model/orm.py
+++ b/freezing/model/orm.py
@@ -99,6 +99,7 @@ class Ride(StravaEntity):
     track_fetched = Column(Boolean, default=None, nullable=True)
     detail_fetched = Column(Boolean, default=False, nullable=False)
     resync_count = Column(Integer, default=0, nullable=False)
+    resync_date = Column(DateTime, nullable=True)
 
     private = Column(Boolean, default=False, nullable=False)
     manual = Column(Boolean, default=None, nullable=True)


### PR DESCRIPTION
In order to handle strava's delayed consistency we need to do some delayed resync of each ride in order to pull missing efforts. Previous attempt assumed that any efforts returned meant that all efforts were done but that proved not to be true.