### PR TITLE
Fix pip GitHub package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 SQLAlchemy>=1.2.1,<1.3.0
-git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
+https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz
 alembic==0.9.7
 marshmallow==3.5.1
 marshmallow-enum==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ SQLAlchemy>=1.2.1,<1.3.0
 https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz
 alembic==0.9.7
 marshmallow==3.14.1
-marshmallow-enum==1.5.1
+marshmallow-enum @ https://github.com/lyft/marshmallow_enum/archive/support-for-marshamallow-3.tar.gz
 PyMySQL==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SQLAlchemy>=1.2.1,<1.3.0
 https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz
 alembic==0.9.7
-marshmallow==3.5.1
-marshmallow-enum==1.4.1
+marshmallow==3.14.1
+marshmallow-enum==1.5.1
 PyMySQL==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import warnings
 
 from setuptools import setup, find_packages
 
-version = '0.5.18'
+version = '0.5.19'
 
 long_description = """
 freezing-model is the database model and message definitions shared by freezing saddles components.
@@ -14,10 +14,10 @@ freezing-model is the database model and message definitions shared by freezing 
 install_reqs = [
 'SQLAlchemy>=1.2.1,<1.3.0',
 'GeoAlchemy',
-'alembic==0.9.7',
-'marshmallow==3.5.1',
-'marshmallow-enum==1.4.1',
-'PyMySQL==0.9.3'
+'alembic',
+'marshmallow',
+'marshmallow-enum',
+'PyMySQL'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import warnings
 
 from setuptools import setup, find_packages
 
-version = '0.5.17'
+version = '0.5.18'
 
 long_description = """
 freezing-model is the database model and message definitions shared by freezing saddles components.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ freezing-model is the database model and message definitions shared by freezing 
 
 install_reqs = [
 'SQLAlchemy>=1.2.1,<1.3.0',
-'https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz',
+'GeoAlchemy',
 'alembic==0.9.7',
 'marshmallow==3.5.1',
 'marshmallow-enum==1.4.1',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import warnings
 
 from setuptools import setup, find_packages
 
-version = '0.5.15'
+version = '0.5.17'
 
 long_description = """
 freezing-model is the database model and message definitions shared by freezing saddles components.
@@ -13,7 +13,7 @@ freezing-model is the database model and message definitions shared by freezing 
 
 install_reqs = [
 'SQLAlchemy>=1.2.1,<1.3.0',
-'GeoAlchemy',
+'https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz',
 'alembic==0.9.7',
 'marshmallow==3.5.1',
 'marshmallow-enum==1.4.1',


### PR DESCRIPTION
I wanted to simplify how pip is handling GitHub package references. Along the way we needed to fix a marshmallow-enum issue that showed up in freezing-sync and we used the Lyft branch used as a PR source in https://github.com/justanr/marshmallow_enum/pull/34 - which has not gotten merged yet - and freezing-sync started working again.

This was the telltale:


```
freezing-sync        | 2021-12-07T02:25:54.459196791Z INFO     [freezing.sync.subscribe] Received message: '{"activity_id": 6352817757, "event_time": "2021-12-07T02:18:47+00:00", "operation": "update", "updates": {"title": "Day 20: Warm and Windy and Wonderful"}, "athlete_id": 32325810}'
freezing-sync        | 2021-12-07T02:25:54.459215544Z ERROR    [freezing.sync.subscribe] Error processing message, will requeue w/ delay of 300 seconds.
freezing-sync        | 2021-12-07T02:25:54.459220671Z Traceback (most recent call last):
freezing-sync        | 2021-12-07T02:25:54.459224773Z   File "/usr/local/lib/python3.6/dist-packages/freezing/sync/subscribe.py", line 96, in run_forever
freezing-sync        | 2021-12-07T02:25:54.459229053Z     update = schema.loads(job.body)
freezing-sync        | 2021-12-07T02:25:54.459232729Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 756, in loads
freezing-sync        | 2021-12-07T02:25:54.459236383Z     return self.load(data, many=many, partial=partial, unknown=unknown)
freezing-sync        | 2021-12-07T02:25:54.459239936Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 723, in load
freezing-sync        | 2021-12-07T02:25:54.459243701Z     data, many=many, partial=partial, unknown=unknown, postprocess=True
freezing-sync        | 2021-12-07T02:25:54.459263097Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 861, in _do_load
freezing-sync        | 2021-12-07T02:25:54.459272015Z     unknown=unknown,
freezing-sync        | 2021-12-07T02:25:54.459274827Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 669, in _deserialize
freezing-sync        | 2021-12-07T02:25:54.459277517Z     index=index,
freezing-sync        | 2021-12-07T02:25:54.459279962Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 493, in _call_and_store
freezing-sync        | 2021-12-07T02:25:54.459282597Z     value = getter_func(data)
freezing-sync        | 2021-12-07T02:25:54.459285053Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/schema.py", line 662, in <lambda>
freezing-sync        | 2021-12-07T02:25:54.459287877Z     val, field_name, data, **d_kwargs
freezing-sync        | 2021-12-07T02:25:54.459290403Z   File "/usr/local/lib/python3.6/dist-packages/marshmallow/fields.py", line 342, in deserialize
freezing-sync        | 2021-12-07T02:25:54.459293050Z     output = self._deserialize(value, attr, data, **kwargs)
freezing-sync        | 2021-12-07T02:25:54.459295749Z TypeError: _deserialize() got an unexpected keyword argument 'partial'
```

That `TypeError _deserialize()` message is an indicator that a class that has a deserialize method has not been updated to take `**kwargs` per https://marshmallow.readthedocs.io/en/stable/upgrading.html