### PR TITLE
Fix marshmallow 3 compatibility issue

### DIFF
--- a/freezing/model/msg/strava.py
+++ b/freezing/model/msg/strava.py
@@ -69,9 +69,9 @@ class SubscriptionCallbackSchema(BaseSchema):
 
     _model_class = SubscriptionCallback
 
-    hub_mode = fields.Str(load_from="hub.mode")
-    hub_verify_token = fields.Str(load_from="hub.verify_token")
-    hub_challenge = fields.Str(load_from="hub.challenge")
+    hub_mode = fields.Str(data_key="hub.mode")
+    hub_verify_token = fields.Str(data_key="hub.verify_token")
+    hub_challenge = fields.Str(data_key="hub.challenge")
 
 
 class SubscriptionUpdate(BaseMessage):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-version = "0.8.6"
+version = "0.8.7"
 
 long_description = """
 freezing-model is the database model and message definitions


### PR DESCRIPTION
https://marshmallow.readthedocs.io/en/stable/upgrading.html states
that load_from has been replaced by data_key. Exercising unit tests
in freezing-nq exposed this.

That code path may not have been exercised in many years for real
as it was used to validate hook.freezingsaddles.org back in 2018.
