### PR TITLE
Store geometry as text in mysql

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-version = "0.8.7"
+version = "0.8.8"
 
 long_description = """
 freezing-model is the database model and message definitions


### PR DESCRIPTION
Low-risk solution to the geoalchemy problem. Store geometry as text in mysql. We don't use any mysql geospatial functions so there's no loss other than space.

Alembic does not run on my machine, and we have no data in production, so I have not attempted any upgrade/downgrade scripts. With no data the DDL update is...

```
alter table ride_tracks modify column gps_track text not null;
alter table ride_geo modify column start_geo varchar(255) not null;
alter table ride_geo modify column end_geo varchar(255) not null;
```
