### PR TITLE
Use pyproject for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freezing-model"
-version = "0.11.0"
+version = "0.11.1"
 description = "shared database model and message definitions for Freezing Saddles"
 readme = "README.md"
 authors = [
@@ -34,9 +34,10 @@ dependencies = [
     "SQLAlchemy~=1.4",
     "alembic",
     "colorlog",
+    "enum34",
     "envparse",
-    "marshmallow-enum @ https://github.com/lyft/marshmallow_enum/archive/support-for-marshamallow-3.tar.gz",
-    "marshmallow==3.23.1",
+    "marshmallow",
+    "marshmallow-enum",
     "pytz",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freezing-model"
-version = "0.11.1"
+version = "0.11.2"
 description = "shared database model and message definitions for Freezing Saddles"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "enum34",
     "envparse",
     "marshmallow",
-    "marshmallow-enum",
+    "marshmallow-enum @ https://github.com/lyft/marshmallow_enum/archive/support-for-marshamallow-3.tar.gz",
     "pytz",
 ]
 


### PR DESCRIPTION
ALso: unpin marshmallow versions.

If we are lucky, we won't see the issues we saw in 2021 related to marshmallow and marshmallow-enum: https://github.com/freezingsaddles/freezing-model/pull/32 _**Spoiler: we were not lucky**_
