### PR TITLE
fix: check for existing columns before adding in migrations

### DIFF
--- a/freezing/model/migrations/versions/3361172cfdc9_add_access_token.py
+++ b/freezing/model/migrations/versions/3361172cfdc9_add_access_token.py
@@ -16,7 +16,17 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column("athletes", sa.Column("access_token", sa.String(255)))
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() "
+            "AND table_name = 'athletes' "
+            "AND column_name = 'access_token'"
+        )
+    )
+    if result.scalar() == 0:
+        op.add_column("athletes", sa.Column("access_token", sa.String(255)))
 
 
 def downgrade():

--- a/freezing/model/migrations/versions/a3aee1eb0fb_add_athlete_display_name.py
+++ b/freezing/model/migrations/versions/a3aee1eb0fb_add_athlete_display_name.py
@@ -15,7 +15,17 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column("athletes", sa.Column("display_name", sa.String(255)))
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() "
+            "AND table_name = 'athletes' "
+            "AND column_name = 'display_name'"
+        )
+    )
+    if result.scalar() == 0:
+        op.add_column("athletes", sa.Column("display_name", sa.String(255)))
 
 
 def downgrade():


### PR DESCRIPTION
## Problem

Fresh database installs fail with `(1060, "Duplicate column name")` when 
Alembic tries to run migrations `3361172cfdc9` (add_access_token) and 
`a3aee1eb0fb` (add_athlete_display_name). This happens because the initial 
schema already includes these columns, so the ALTER TABLE statements fail.

## Fix

Added `information_schema` checks to both `upgrade()` functions to verify 
whether the column exists before attempting to add it. If the column is 
already present, the migration is safely skipped.

## Notes

This is a regression of #4 (Bootstrapping database from scratch is not 
working), which was previously fixed but broke again as the schema evolved.

Tested on macOS Tahoe with MySQL 8.0 running in Docker.